### PR TITLE
prysm: set --contract-deployment-block 

### DIFF
--- a/ansible/inventories/devnet-4/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-4/group_vars/all/all.yaml
@@ -1,13 +1,32 @@
+#  ░██████╗░██╗░░░░░░█████╗░██████╗░░█████╗░██╗░░░░░  ██╗░░░██╗░█████╗░██████╗░░██████╗
+#  ██╔════╝░██║░░░░░██╔══██╗██╔══██╗██╔══██╗██║░░░░░  ██║░░░██║██╔══██╗██╔══██╗██╔════╝
+#  ██║░░██╗░██║░░░░░██║░░██║██████╦╝███████║██║░░░░░  ╚██╗░██╔╝███████║██████╔╝╚█████╗░
+#  ██║░░╚██╗██║░░░░░██║░░██║██╔══██╗██╔══██║██║░░░░░  ░╚████╔╝░██╔══██║██╔══██╗░╚═══██╗
+#  ╚██████╔╝███████╗╚█████╔╝██████╦╝██║░░██║███████╗  ░░╚██╔╝░░██║░░██║██║░░██║██████╔╝
+#  ░╚═════╝░╚══════╝░╚════╝░╚═════╝░╚═╝░░╚═╝╚══════╝  ░░░╚═╝░░░╚═╝░░╚═╝╚═╝░░╚═╝╚═════╝░
+
 server_fqdn: "{{ inventory_hostname }}.server.{{ ethereum_network_name }}.ethpandaops.io"
 
 ethereum_network_id: >-
   {{ (lookup('file', eth_testnet_config_local_dir_src + '/genesis.json') | from_json).config.chainId }}
+ethereum_network_deposit_contract: >-
+  {{ lookup('file', eth_testnet_config_local_dir_src + '/deposit_contract.txt') }}
+ethereum_network_deposit_contract_block: >-
+  {{ lookup('file', eth_testnet_config_local_dir_src + '/deposit_contract_block.txt') }}
 
 ethereum_node_rcp_hostname: "rpc.{{ server_fqdn }}"
 ethereum_node_beacon_hostname: "beacon.{{ server_fqdn }}"
 
 ethstats_url: "ethstats.eip{{ ethereum_network_name }}.ethpandaops.io"
 ethstats_secret: "{{ secret_ethstats }}"
+
+
+#  ██████╗░░█████╗░██╗░░░░░███████╗  ██╗░░░██╗░█████╗░██████╗░░██████╗
+#  ██╔══██╗██╔══██╗██║░░░░░██╔════╝  ██║░░░██║██╔══██╗██╔══██╗██╔════╝
+#  ██████╔╝██║░░██║██║░░░░░█████╗░░  ╚██╗░██╔╝███████║██████╔╝╚█████╗░
+#  ██╔══██╗██║░░██║██║░░░░░██╔══╝░░  ░╚████╔╝░██╔══██║██╔══██╗░╚═══██╗
+#  ██║░░██║╚█████╔╝███████╗███████╗  ░░╚██╔╝░░██║░░██║██║░░██║██████╔╝
+#  ╚═╝░░╚═╝░╚════╝░╚══════╝╚══════╝  ░░░╚═╝░░░╚═╝░░╚═╝╚═╝░░╚═╝╚═════╝░
 
 # role: ethpandaops.general.bootstrap
 bootstrap_default_user_authorized_keys_github_all:

--- a/ansible/inventories/devnet-4/group_vars/bootnode.yaml
+++ b/ansible/inventories/devnet-4/group_vars/bootnode.yaml
@@ -46,6 +46,7 @@ prysm_container_command_extra_args:
   - --grpc-gateway-corsdomain=*
   - --chain-config-file=/network-config/config.yaml
   - --genesis-state=/network-config/genesis.ssz
+  - --contract-deployment-block={{ ethereum_network_deposit_contract_block }}
   - --min-sync-peers=1
   - --pprof
   - --enable-debug-rpc-endpoints

--- a/ansible/inventories/devnet-4/group_vars/prysm.yaml
+++ b/ansible/inventories/devnet-4/group_vars/prysm.yaml
@@ -35,6 +35,7 @@ prysm_container_command_extra_simple_args:
   - --grpc-gateway-corsdomain=*
   - --chain-config-file=/network-config/config.yaml
   - --genesis-state=/network-config/genesis.ssz
+  - --contract-deployment-block={{ ethereum_network_deposit_contract_block }}
   - --min-sync-peers=1
   - --pprof
   - --enable-debug-rpc-endpoints


### PR DESCRIPTION
Thanks @barnabasbusa for saving me a couple of hours in the future :D 

Just a recap from my findings:
 
- lodestar expect `deposit_contract_block.txt` in network dir 
- lighthouse expects `deploy_block.txt` in network dir
- prysm needs the flag `--contract-deployment-block`
- nimbus expects `deploy_block.txt` in the network dir
- teku defaults to 0 if's not a known hardcoded network config
