### PR TITLE
shorten dns names due to 64 chars limit on certs

### DIFF
--- a/ansible/inventories/devnet-4/group_vars/all/all.yaml
+++ b/ansible/inventories/devnet-4/group_vars/all/all.yaml
@@ -5,7 +5,7 @@
 #  ╚██████╔╝███████╗╚█████╔╝██████╦╝██║░░██║███████╗  ░░╚██╔╝░░██║░░██║██║░░██║██████╔╝
 #  ░╚═════╝░╚══════╝░╚════╝░╚═════╝░╚═╝░░╚═╝╚══════╝  ░░░╚═╝░░░╚═╝░░╚═╝╚═╝░░╚═╝╚═════╝░
 
-server_fqdn: "{{ inventory_hostname }}.server.{{ ethereum_network_name }}.ethpandaops.io"
+server_fqdn: "{{ inventory_hostname }}.srv.{{ ethereum_network_name }}.ethpandaops.io"
 
 ethereum_network_id: >-
   {{ (lookup('file', eth_testnet_config_local_dir_src + '/genesis.json') | from_json).config.chainId }}
@@ -15,7 +15,7 @@ ethereum_network_deposit_contract_block: >-
   {{ lookup('file', eth_testnet_config_local_dir_src + '/deposit_contract_block.txt') }}
 
 ethereum_node_rcp_hostname: "rpc.{{ server_fqdn }}"
-ethereum_node_beacon_hostname: "beacon.{{ server_fqdn }}"
+ethereum_node_beacon_hostname: "bn.{{ server_fqdn }}"
 
 ethstats_url: "ethstats.eip{{ ethereum_network_name }}.ethpandaops.io"
 ethstats_secret: "{{ secret_ethstats }}"

--- a/terraform/environments/devnet-4/main.tf
+++ b/terraform/environments/devnet-4/main.tf
@@ -336,7 +336,7 @@ resource "cloudflare_record" "server_record" {
     for vm in local.digitalocean_vms : "${vm.id}" => vm
   }
   zone_id = data.cloudflare_zone.default.id
-  name    = "${each.value.name}.server.${var.ethereum_network}"
+  name    = "${each.value.name}.srv.${var.ethereum_network}"
   type    = "A"
   value   = digitalocean_droplet.main[each.value.id].ipv4_address
   proxied = false
@@ -348,7 +348,7 @@ resource "cloudflare_record" "server_record_rpc" {
     for vm in local.digitalocean_vms : "${vm.id}" => vm
   }
   zone_id = data.cloudflare_zone.default.id
-  name    = "rpc.${each.value.name}.server.${var.ethereum_network}"
+  name    = "rpc.${each.value.name}.srv.${var.ethereum_network}"
   type    = "A"
   value   = digitalocean_droplet.main[each.value.id].ipv4_address
   proxied = false
@@ -360,7 +360,7 @@ resource "cloudflare_record" "server_record_beacon" {
     for vm in local.digitalocean_vms : "${vm.id}" => vm
   }
   zone_id = data.cloudflare_zone.default.id
-  name    = "beacon.${each.value.name}.server.${var.ethereum_network}"
+  name    = "bn.${each.value.name}.srv.${var.ethereum_network}"
   type    = "A"
   value   = digitalocean_droplet.main[each.value.id].ipv4_address
   proxied = false


### PR DESCRIPTION
Due to 

``` 
[Fri Feb  3 17:09:06 UTC 2023] Single domain='beacon.lighthouse-nethermind-1.server.4844-devnet-4.ethpandaops.io'
481B30CCB27F0000:error:06800097:asn1 encoding routines:ASN1_mbstring_ncopy:string too long:crypto/asn1/a_mbstr.c:106:maxsize=64
req: Error adding subject name attribute "/CN=beacon.lighthouse-nethermind-1.server.4844-devnet-4.ethpandaops.io"
[Fri Feb  3 17:09:06 UTC 2023] Create CSR error.
[Fri Feb  3 17:09:06 UTC 2023] Please check log file for more details: /dev/null
``` 