### PR TITLE
fixup bootnodes

### DIFF
--- a/ansible/inventories/devnet-5/group_vars/bootnode.yaml
+++ b/ansible/inventories/devnet-5/group_vars/bootnode.yaml
@@ -1,4 +1,5 @@
-ethereum_cl_bootnode: "{{ hostvars['bootnode-1']['cl_bootnode_fact_enr'] }}"
+ethereum_cl_bootnodes:
+  - "{{ hostvars['bootnode-1']['cl_bootnode_fact_enr'] }}"
 
 # role: eth_inventory_web
 eth_inventory_web_container_networks: "{{ docker_networks_shared }}"
@@ -45,6 +46,7 @@ lodestar_container_command_extra_args:
   - --paramsFile=/network-config/config.yaml
   - --genesisStateFile=/network-config/genesis.ssz
   #- --logLevel=debug
+  - --bootnodes={{ ethereum_cl_bootnodes | join(',') }}
   - --network.connectToDiscv5Bootnodes
   - --nat=true
 

--- a/ansible/inventories/devnet-5/group_vars/ethereum_node.yaml
+++ b/ansible/inventories/devnet-5/group_vars/ethereum_node.yaml
@@ -1,9 +1,6 @@
 ethereum_cl_bootnodes:
   - "{{ hostvars['bootnode-1']['cl_bootnode_fact_enr'] }}"
   - "{{ hostvars['bootnode-1']['ethereum_node_fact_cl_enr'] }}"
-  - "{{ hostvars['lodestar-ethereumjs-1']['ethereum_node_fact_cl_enr'] }}"
-  - "{{ hostvars['lodestar-geth-1']['ethereum_node_fact_cl_enr'] }}"
-
 
 ethereum_el_bootnode: "{{ hostvars['bootnode-1']['ethereum_node_fact_el_enode'] }}"
 


### PR DESCRIPTION
- Lodestar on bootnode-1 needs to connect to the CL bootnode
- Other nodes should only use bootnode-1 as the bootnode, to avoid circular dependencies when setting up the network